### PR TITLE
fix: resolve all ruff lint errors

### DIFF
--- a/src/modelaudit/mcp_server.py
+++ b/src/modelaudit/mcp_server.py
@@ -446,7 +446,7 @@ def create_server() -> "Server":
                         # Check for unusually uniform word length distribution
                         lengths = [len(w) for w in words]
                         mean_len = sum(lengths) / len(lengths)
-                        variance = sum((l - mean_len) ** 2 for l in lengths) / len(lengths)
+                        variance = sum((wl - mean_len) ** 2 for wl in lengths) / len(lengths)
                         # Low variance in word lengths can indicate watermarking
                         if variance < 2.0:
                             score += 0.3


### PR DESCRIPTION
清理全部 ruff lint 错误，CI 门禁现在能通过了。仅修 lint，不改功能逻辑。