### PR TITLE
chore: migrate to reusable PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,33 +2,13 @@ name: Publish to PyPI
 
 on:
   push:
-    tags:
-      - "v*"
-
-permissions:
-  contents: read
+    tags: ["v*"]
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    environment: pypi
+    uses: liuxiaotong/knowlyr-workflows/.github/workflows/reusable-publish-pypi.yml@main
+    with:
+      build_tool: "setuptools"
     permissions:
       id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install build tools
-        run: pip install build
-
-      - name: Build package
-        run: python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      contents: read


### PR DESCRIPTION
## Summary
- Replaces inline publish workflow with caller to `knowlyr-workflows/reusable-publish-pypi.yml`
- Uses setuptools build + trusted publisher
- Part of TD-2026-004 Phase 1

## Test plan
- [ ] Next `v*` tag push triggers the reusable workflow correctly